### PR TITLE
Website: name change Azure -> Azure Stack

### DIFF
--- a/website/azurestack.erb
+++ b/website/azurestack.erb
@@ -8,7 +8,7 @@
             </li>
 
             <li<%= sidebar_current("docs-azurestack-index") %>>
-              <a href="/docs/providers/azurestack/index.html">Azure Provider</a>
+              <a href="/docs/providers/azurestack/index.html">Azure Stack Provider</a>
               <ul class="nav nav-visible">
                 <li<%= sidebar_current("docs-azurestack-index-authentication-service-principal") %>>
                     <a href="/docs/providers/azurestack/authenticating_via_service_principal.html">Authenticating via a Service Principal (Shared Account)</a>


### PR DESCRIPTION
Update sidebar navigation link from "Azure Provider" to "Azure Stack Provider"