### PR TITLE
azurestack_public_ip: correct import & read idle_timeout_in_minutes

### DIFF
--- a/azurestack/resource_arm_public_ip.go
+++ b/azurestack/resource_arm_public_ip.go
@@ -63,6 +63,7 @@ func resourceArmPublicIp() *schema.Resource {
 			"idle_timeout_in_minutes": {
 				Type:         schema.TypeInt,
 				Optional:     true,
+				Default:      4,
 				ValidateFunc: validation.IntBetween(4, 30),
 			},
 
@@ -131,12 +132,14 @@ func resourceArmPublicIpCreate(d *schema.ResourceData, meta interface{}) error {
 	// }
 
 	ipAllocationMethod := d.Get("public_ip_address_allocation").(string)
+	idleTimeout := d.Get("idle_timeout_in_minutes").(int)
 
 	publicIp := network.PublicIPAddress{
 		Name:     &name,
 		Location: &location,
 		PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 			PublicIPAllocationMethod: network.IPAllocationMethod(ipAllocationMethod),
+			IdleTimeoutInMinutes:     utils.Int32(int32(idleTimeout)),
 		},
 		Tags: *expandTags(tags),
 		// Not supported for 2017-03-09 profile
@@ -161,10 +164,6 @@ func resourceArmPublicIpCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		publicIp.PublicIPAddressPropertiesFormat.DNSSettings = &dnsSettings
-	}
-
-	if v, ok := d.GetOk("idle_timeout_in_minutes"); ok {
-		publicIp.PublicIPAddressPropertiesFormat.IdleTimeoutInMinutes = utils.Int32(int32(v.(int)))
 	}
 
 	future, err := client.CreateOrUpdate(ctx, resGroup, name, publicIp)

--- a/azurestack/resource_arm_public_ip.go
+++ b/azurestack/resource_arm_public_ip.go
@@ -226,18 +226,11 @@ func resourceArmPublicIpRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("public_ip_address_allocation", strings.ToLower(string(props.PublicIPAllocationMethod)))
 
 		if settings := props.DNSSettings; settings != nil {
-			if fqdn := settings.Fqdn; fqdn != nil {
-				d.Set("fqdn", fqdn)
-			}
+			d.Set("fqdn", settings.Fqdn)
 		}
 
-		if ip := props.IPAddress; ip != nil {
-			d.Set("ip_address", ip)
-		}
-
-		if idleTimeout := props.IdleTimeoutInMinutes; idleTimeout != nil {
-			d.Set("idle_timeout_in_minutes", idleTimeout)
-		}
+		d.Set("ip_address", props.IPAddress)
+		d.Set("idle_timeout_in_minutes", props.IdleTimeoutInMinutes)
 	}
 
 	flattenAndSetTags(d, &resp.Tags)

--- a/azurestack/resource_arm_public_ip_test.go
+++ b/azurestack/resource_arm_public_ip_test.go
@@ -3,13 +3,13 @@ package azurestack
 import (
 	"fmt"
 	"net/http"
+	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"os"
-	"regexp"
 )
 
 func TestResourceAzureStackPublicIpDomainNameLabel_validation(t *testing.T) {

--- a/azurestack/resource_arm_public_ip_test.go
+++ b/azurestack/resource_arm_public_ip_test.go
@@ -12,42 +12,6 @@ import (
 	"regexp"
 )
 
-func TestResourceAzureStackPublicIpAllocation_validation(t *testing.T) {
-	cases := []struct {
-		Value    string
-		ErrCount int
-	}{
-		{
-			Value:    "Random",
-			ErrCount: 1,
-		},
-		{
-			Value:    "Static",
-			ErrCount: 0,
-		},
-		{
-			Value:    "Dynamic",
-			ErrCount: 0,
-		},
-		{
-			Value:    "STATIC",
-			ErrCount: 0,
-		},
-		{
-			Value:    "static",
-			ErrCount: 0,
-		},
-	}
-
-	for _, tc := range cases {
-		_, errors := validatePublicIpAllocation(tc.Value, "azurestack_public_ip")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the Azure RM Public IP allocation to trigger a validation error")
-		}
-	}
-}
-
 func TestResourceAzureStackPublicIpDomainNameLabel_validation(t *testing.T) {
 	cases := []struct {
 		Value    string

--- a/azurestack/resource_arm_route_table.go
+++ b/azurestack/resource_arm_route_table.go
@@ -116,7 +116,7 @@ func resourceArmRouteTableCreateUpdate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error Creating/Updating Route Table %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("Error waiting for completion of Route Table %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
@@ -192,7 +192,7 @@ func resourceArmRouteTableDelete(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("Error waiting for deletion of Route Table %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 

--- a/azurestack/resource_arm_virtual_network_gateway.go
+++ b/azurestack/resource_arm_virtual_network_gateway.go
@@ -298,7 +298,7 @@ func resourceArmVirtualNetworkGatewayCreateUpdate(d *schema.ResourceData, meta i
 		return fmt.Errorf("Error Creating/Updating AzureRM Virtual Network Gateway %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("Error waiting for completion of AzureRM Virtual Network Gateway %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
@@ -393,7 +393,7 @@ func resourceArmVirtualNetworkGatewayDelete(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Error deleting Virtual Network Gateway %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("Error waiting for deletion of Virtual Network Gateway %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 

--- a/azurestack/resource_arm_virtual_network_gateway_connection.go
+++ b/azurestack/resource_arm_virtual_network_gateway_connection.go
@@ -132,7 +132,7 @@ func resourceArmVirtualNetworkGatewayConnectionCreateUpdate(d *schema.ResourceDa
 		return fmt.Errorf("Error Creating/Updating AzureRM Virtual Network Gateway Connection %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("Error waiting for completion of Virtual Network Gateway Connection %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
@@ -240,7 +240,7 @@ func resourceArmVirtualNetworkGatewayConnectionDelete(d *schema.ResourceData, me
 		return fmt.Errorf("Error Deleting Virtual Network Gateway Connection %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("Error waiting for deletion of Virtual Network Gateway Connection %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 


### PR DESCRIPTION
fixes the following import error:

```
------- Stdout: -------
=== RUN   TestAccAzureStackPublicIpStatic_idleTimeout
--- FAIL: TestAccAzureStackPublicIpStatic_idleTimeout (71.27s)
	testing.go:513: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
		
		(map[string]string) {
		}
		
		
		(map[string]string) (len=1) {
		 (string) (len=23) "idle_timeout_in_minutes": (string) (len=2) "30"
		}
		
FAIL
```

(and its nice if changes to the value are read back in)