### PR TITLE
authentication: support for Client Certificate authentication

### DIFF
--- a/azurestack/provider.go
+++ b/azurestack/provider.go
@@ -13,10 +13,10 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-// Provider returns a terraform.ResourceProvider.
 func Provider() terraform.ResourceProvider {
 	p := &schema.Provider{
 		Schema: map[string]*schema.Schema{
+			// TODO: deprecate this local key in favour of `endpoint` in the futures
 			"arm_endpoint": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -32,6 +32,18 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("ARM_CLIENT_ID", ""),
+			},
+
+			"client_certificate_path": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ARM_CLIENT_CERTIFICATE_PATH", ""),
+			},
+
+			"client_certificate_password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ARM_CLIENT_CERTIFICATE_PASSWORD", ""),
 			},
 
 			"client_secret": {
@@ -116,11 +128,14 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 			ClientID:                      d.Get("client_id").(string),
 			ClientSecret:                  d.Get("client_secret").(string),
 			TenantID:                      d.Get("tenant_id").(string),
-			Environment:                   "AZURESTACKCLOUD",
+			ClientCertPath:                d.Get("client_certificate_path").(string),
+			ClientCertPassword:            d.Get("client_certificate_password").(string),
 			CustomResourceManagerEndpoint: d.Get("arm_endpoint").(string),
+			Environment:                   "AZURESTACKCLOUD",
 
 			// Feature Toggles
 			SupportsClientSecretAuth: true,
+			SupportsClientCertAuth:   true,
 		}
 		config, err := builder.Build()
 		if err != nil {

--- a/website/azurestack.erb
+++ b/website/azurestack.erb
@@ -14,10 +14,13 @@
             <li<%= sidebar_current("docs-azurestack-auth") %>>
               <a href="/docs/providers/azurestack/auth/index.html">Authentication</a>
               <ul class="nav nav-visible">
+                <li<%= sidebar_current("docs-azurestack-auth-service-principal-client-certificate") %>>
+                    <a href="/docs/providers/azurestack/auth/service_principal_client_certificate.html">via Service Principal (Client Certificate)</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azurestack-auth-service-principal-client-secret") %>>
                     <a href="/docs/providers/azurestack/auth/service_principal_client_secret.html">via Service Principal (Client Secret)</a>
                 </li>
-
               </ul>
             </li>
 

--- a/website/azurestack.erb
+++ b/website/azurestack.erb
@@ -9,17 +9,21 @@
 
             <li<%= sidebar_current("docs-azurestack-index") %>>
               <a href="/docs/providers/azurestack/index.html">Azure Stack Provider</a>
+            </li>
+
+            <li<%= sidebar_current("docs-azurestack-auth") %>>
+              <a href="/docs/providers/azurestack/auth/index.html">Authentication</a>
               <ul class="nav nav-visible">
-                <li<%= sidebar_current("docs-azurestack-index-authentication-service-principal") %>>
-                    <a href="/docs/providers/azurestack/authenticating_via_service_principal.html">Authenticating via a Service Principal (Shared Account)</a>
+                <li<%= sidebar_current("docs-azurestack-auth-service-principal-client-secret") %>>
+                    <a href="/docs/providers/azurestack/auth/service_principal_client_secret.html">via Service Principal (Client Secret)</a>
                 </li>
+
               </ul>
             </li>
 
             <li<%= sidebar_current("docs-azurestack-datasource") %>>
               <a href="#">Data Sources</a>
               <ul class="nav nav-visible">
-
                 <li<%= sidebar_current("docs-azurestack-datasource-network-interface") %>>
                     <a href="/docs/providers/azurestack/d/network_interface.html">azurestack_network_interface</a>
                 </li>
@@ -27,7 +31,7 @@
                 <li<%= sidebar_current("docs-azurestack-datasource-network-security-group") %>>
                     <a href="/docs/providers/azurestack/d/network_security_group.html">azurestack_network_security_group</a>
                 </li>
-                
+
                 <li<%= sidebar_current("docs-azurestack-datasource-public_ip") %>>
                     <a href="/docs/providers/azurestack/d/public_ip.html">azurestack_public_ip</a>
                 </li>
@@ -40,20 +44,21 @@
                   <a href="/docs/providers/azurestack/d/route_table.html">azurestack_route_table</a>
                 </li>
 
-
                 <li<%= sidebar_current("docs-azurestack-datasource-storage-account") %>>
                     <a href="/docs/providers/azurestack/d/storage_account.html">azurestack_storage_account</a>
                 </li>
+
                 <li<%= sidebar_current("docs-azurestack-datasource-subnet") %>>
                     <a href="/docs/providers/azurestack/d/subnet.html">azurestack_subnet</a>
                 </li>
+
                 <li<%= sidebar_current("docs-azurestack-datasource-virtual-network-x") %>>
                     <a href="/docs/providers/azurestack/d/virtual_network.html">azurestack_virtual_network</a>
                 </li>
+
                 <li<%= sidebar_current("docs-azurestack-datasource-virtual-network-gateway") %>>
                     <a href="/docs/providers/azurestack/d/virtual_network_gateway.html">azurestack_virtual_network_gateway</a>
                 </li>
-
               </ul>
             </li>
 
@@ -69,7 +74,6 @@
             <li<%= sidebar_current("docs-azurestack-resource-compute") %>>
               <a href="#">Compute Resources</a>
               <ul class="nav nav-visible">
-
                 <li<%= sidebar_current("docs-azurestack-resource-compute-availability-set") %>>
                   <a href="/docs/providers/azurestack/r/availability_set.html">azurestack_availability_set</a>
                 </li>
@@ -80,18 +84,17 @@
 
                 <li<%= sidebar_current("docs-azurestack-resource-compute-virtualmachine-extension") %>>
                   <a href="/docs/providers/azurestack/r/virtual_machine_extension.html">azurestack_virtual_machine_extension</a>
-                
-                </li><li<%= sidebar_current("docs-azurestack-resource-compute-virtualmachine-scale_set") %>>
-                  <a href="/docs/providers/azurestack/r/virtual_machine_scale_set.html">azurestack_virtual_machine_scale_set</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurestack-resource-compute-virtualmachine-scale_set") %>>
+                  <a href="/docs/providers/azurestack/r/virtual_machine_scale_set.html">azurestack_virtual_machine_scale_set</a>
+                </li>
               </ul>
             </li>
 
             <li<%= sidebar_current("docs-azurestack-resource-dns") %>>
                 <a href="#">DNS Resources</a>
                 <ul class="nav nav-visible">
-
                   <li<%= sidebar_current("docs-azurestack-resource-dns-a-record") %>>
                     <a href="/docs/providers/azurestack/r/dns_a_record.html">azurestack_dns_a_record</a>
                   </li>
@@ -99,14 +102,12 @@
                   <li<%= sidebar_current("docs-azurestack-resource-dns-zone") %>>
                       <a href="/docs/providers/azurestack/r/dns_zone.html">azurestack_dns_zone</a>
                   </li>
-
                 </ul>
             </li>
 
             <li<%= sidebar_current("docs-azurestack-resource-network") %>>
               <a href="#">Network Resources</a>
               <ul class="nav nav-visible">
-
                 <li<%= sidebar_current("docs-azurestack-resource-local-network-gateway") %>>
                   <a href="/docs/providers/azurestack/r/local_network_gateway.html">azurestack_local_network_gateway</a>
                 </li>
@@ -171,7 +172,6 @@
             <li<%= sidebar_current("docs-azurestack-resource-loadbalancer") %>>
               <a href="#">Load Balancer Resources</a>
               <ul class="nav nav-visible">
-
                   <li<%= sidebar_current("docs-azurestack-resource-loadbalancer-x") %>>
                     <a href="/docs/providers/azurestack/r/loadbalancer.html">azurestack_lb</a>
                   </li>
@@ -195,7 +195,6 @@
                   <li<%= sidebar_current("docs-azurestack-resource-loadbalancer-nat-pool") %>>
                     <a href="/docs/providers/azurestack/r/loadbalancer_nat_pool.html">azurestack_lb_nat_pool</a>
                   </li>
-
               </ul>
             </li>
 

--- a/website/azurestack.erb
+++ b/website/azurestack.erb
@@ -12,7 +12,7 @@
             </li>
 
             <li<%= sidebar_current("docs-azurestack-auth") %>>
-              <a href="/docs/providers/azurestack/auth/index.html">Authentication</a>
+              <a href="#">Authentication</a>
               <ul class="nav nav-visible">
                 <li<%= sidebar_current("docs-azurestack-auth-service-principal-client-certificate") %>>
                     <a href="/docs/providers/azurestack/auth/service_principal_client_certificate.html">via Service Principal (Client Certificate)</a>

--- a/website/docs/auth/service_principal_client_certificate.html.markdown
+++ b/website/docs/auth/service_principal_client_certificate.html.markdown
@@ -1,0 +1,119 @@
+---
+layout: "azurestack"
+page_title: "Azure Stack Provider: Authenticating via a Service Principal using a Client Certificate"
+sidebar_current: "docs-azurestack-auth-service-principal-client-certificate"
+description: |-
+  This guide explains how to use a Service Principal and a Client Certificate to authenticate with the Azure Stack Provider.
+
+---
+
+# Azure Stack Provider: Authenticating using a Service Principal using a Client Certificate
+
+Terraform supports authenticating to Azure Stack using a Service Principal, either [using a Client Secret](service_principal_client_secret.html) or using a Client Certificate (which is detailed in this guide).
+
+## Creating a Service Principal
+
+A Service Principal is an application within Azure Active Directory which can have authentication tokens associated with it. In this example we'll generate a new certificate, then create and assign it to a Service Principal; so that it can be used for authentication.
+
+### Creating a Service Principal in the Azure Portal
+
+~> **NOTE:** This needs to be completed in the main Azure (Public) Portal - not the Azure Stack Portal.
+
+There are three tasks needed to create a Service Principal via [the Azure Portal](https://portal.azure.com):
+
+ 1. Generating a Certificate which can be used for Authentication
+ 2. Create an Application in Azure Active Directory (which acts as a Service Principal) and then associating the Certificate with it
+ 2. Grant the Application access to manage resources in your Azure Subscription
+
+### 1. Generating a Certificate
+
+Firstly we need to create a certificate which can be used for authentication. To do that we're going to generate a Certificate Signing Request (also known as a CSR) using `openssl` (this can also be achieved using PowerShell, however that's outside the scope of this document):
+
+```bash
+$ openssl req \
+   -newkey rsa:4096 -nodes -keyout "service-principal.key" \
+   -out "service-principal.csr"
+```
+
+We can now sign that Certificate Signing Request, in this example we're going to self-sign this certificate using the Key we just generated; however it's also possible to do this using a Certificate Authority. In order to do that we're again going to use `openssl`:
+
+```bash
+$ openssl x509 \
+  -signkey "service-principal.key" \
+  -in "service-principal.csr" \
+  -req -days 365 -out "service-principal.crt"
+```
+
+Finally we can generate a PFX file which can be used to authenticate with Azure:
+
+```
+$ openssl pkcs12 -export -out "service-principal.pfx" -inkey "service-principal.key" -in "service-principal.crt"
+```
+
+Now that we've generated a certificate, we can create the Azure Active Directory application.
+
+### 2. Creating an Application in Azure Active Directory
+
+Firstly navigate to [the **Azure Active Directory** overview](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/Overview) within the Azure Portal - [then select the **App Registration** blade](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps/RegisteredApps/Overview) and click **Endpoints** at the top of the **App Registration** blade. A list of URIs will be displayed and you need to locate the URI for **OAUTH 2.0 AUTHORIZATION ENDPOINT** which contains a GUID. This is your Tenant ID / the `tenant_id` field mentioned above.
+
+Next, navigate back to [the **App Registration** blade](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps/RegisteredApps/Overview) - from here we'll create the Application in Azure Active Directory. To do this click **Add** at the top to add a new Application within Azure Active Directory. On this page, set the following values then press **Create**:
+
+- **Name** - this is a friendly identifier and can be anything (e.g. "Terraform")
+- **Application Type** - this should be set to "Web app / API"
+- **Sign-on URL** - this can be anything, providing it's a valid URI (e.g. https://terra.form)
+
+Once that's done - select the Application you just created in [the **App Registration** blade](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps/RegisteredApps/Overview). At the top of this page, the "Application ID" GUID is the `client_id` you'll need.
+
+Finally need to associate the Client Certificate with the Azure Active Directory Application - to do this select **Settings** and then **Keys**. This screen displays the Passwords (Client Secrets) and Public Keys (Client Certificates) which are associated with this Azure Active Directory Application.
+
+The Public Key associated with the generated Certificate can be uploaded by selecting **Upload Public Key**, selecting the file which should be uploaded (in the example above, this'd be `service-principal.crt`) - and then hitting **Save**.
+
+### 3. Granting the Application access to manage resources in your Azure and Azure Stack Subscriptions
+
+Once the Application exists in Azure Active Directory - we can grant it permissions to modify resources in the Subscription. To do this, [navigate to the **Subscriptions** blade within the Azure Portal](https://portal.azure.com/#blade/Microsoft_Azure_Billing/SubscriptionsBlade), then select the Subscription you wish to use, then click **Access Control (IAM)**, and finally **Add**.
+
+~> **NOTE:**  This will only give SPN access to your Azure Subscription - This is **NOT** required to interact with Azure Stack. To allow SPN access to Azure Stack you need to do it under Azure Stack Subscription [navigate to the **Subscriptions** blade within the Azure Stack Portal](https://portal.{region}.{domain}/#blade/Microsoft_Azure_Billing/SubscriptionsBlade), then select the Subscription you wish to use, then click **Access Control (IAM)**, and finally **Add**.
+
+Firstly, specify a Role which grants the appropriate permissions needed for the Service Principal (for example, `Contributor` will grant Read/Write on all resources in the Subscription). There's more information about [the built in roles available here](https://azure.microsoft.com/en-gb/documentation/articles/role-based-access-built-in-roles/).
+
+Secondly, search for and select the name of the Application created in Azure Active Directory to assign it this role - then press **Save**.
+
+At this point the newly created Azure Active Directory Application should be associated with the Certificate that we generated earlier (which can be used as a Client Certificate) - and should have permissions to the Azure Subscription.
+
+It should then be possible to configure these credentials in Terraform, either by using setting the relevant Environment Variables:
+
+```bash
+export ARM_ENDPOINT="https://management.region.mycloud.com"
+export ARM_CLIENT_CERTIFICATE_PASSWORD="hello-world"
+export ARM_CLIENT_CERTIFICATE_PATH="/Users/myuser/keys/service-principal.pfx"
+export ARM_CLIENT_ID="00000000-0000-0000-0000-000000000000"
+export ARM_SUBSCRIPTION_ID="00000000-0000-0000-0000-000000000000"
+export ARM_TENANT_ID="00000000-0000-0000-0000-000000000000"
+```
+
+and then using the following Provider Block:
+
+```hcl
+provider "azurestack" {
+  # whilst the `version` attribute is optional, we'd recommend pinning to a particular version
+  version = "=0.5.0"
+}
+```
+
+Alternatively you can define these fields within the Provider Block:
+
+```hcl
+provider "azurestack" {
+  # whilst the `version` attribute is optional, we'd recommend pinning to a particular version
+  version = "=0.5.0"
+
+  arm_endpoint                = "https://management.region.mycloud.com"
+  client_id                   = "00000000-0000-0000-0000-000000000000"
+  client_certificate_password = "my-password"
+  client_certificate_path     = "./service-principal.pfx"
+  subscription_id             = "00000000-0000-0000-0000-000000000000"
+  tenant_id                   = "00000000-0000-0000-0000-000000000000"
+}
+```
+
+More information on [the fields supported in the Provider block can be found here](../index.html#argument-reference).

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -70,6 +70,16 @@ The following arguments are supported:
 
 ---
 
+When authenticating as a Service Principal using a Client Certificate, the following fields can be set:
+
+* `client_certificate_password` - (Optional) The password associated with the Client Certificate. This can also be sourced from the `ARM_CLIENT_CERTIFICATE_PASSWORD` Environment Variable.
+
+* `client_certificate_path` - (Optional) The path to the Client Certificate associated with the Service Principal which should be used. This can also be sourced from the `ARM_CLIENT_CERTIFICATE_PATH` Environment Variable.
+
+More information on [how to configure a Service Principal using a Client Certificate can be found in this guide](auth/service_principal_client_certificate.html).
+
+---
+
 When authenticating as a Service Principal using a Client Secret, the following fields can be set:
 
 * `client_secret` - (Optional) The Client Secret which should be used. This can also be sourced from the `ARM_CLIENT_SECRET` Environment Variable.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -15,7 +15,7 @@ Use the navigation to the left to read about the available resources.
 
 # Creating Credentials
 
-Terraform supports authenticating to Azure Stack using a Service Principal, either using [Client Secret](authenticating_via_service_principal.html) or a [Client Certificate](authenticating_via_service_principal.html).
+Terraform supports authenticating to Azure Stack using a Service Principal, either using [Client Secret](auth/service_principal_client_secret.html) or a [Client Certificate](auth/service_principal_client_certificate.html).
 
 ## Example Usage
 
@@ -23,7 +23,7 @@ Terraform supports authenticating to Azure Stack using a Service Principal, eith
 # Configure the Azure Stack Provider
 provider "azurestack" {
   # NOTE: we recommend pinning the version of the Provider which should be used in the Provider block
-  # version = "=1.2.3"
+  # version = "=0.5.0"
 }
 
 # Create a resource group

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -15,26 +15,29 @@ Use the navigation to the left to read about the available resources.
 
 # Creating Credentials
 
-Terraform supports authenticating to Azure Stack through a Service Principal - [this page explains how to Create a Service Principal](authenticating_via_service_principal.html).
+Terraform supports authenticating to Azure Stack using a Service Principal, either using [Client Secret](authenticating_via_service_principal.html) or a [Client Certificate](authenticating_via_service_principal.html).
 
 ## Example Usage
 
 ```hcl
-# Configure the Azure Provider
-provider "azurestack" {}
+# Configure the Azure Stack Provider
+provider "azurestack" {
+  # NOTE: we recommend pinning the version of the Provider which should be used in the Provider block
+  # version = "=1.2.3"
+}
 
 # Create a resource group
-resource "azurestack_resource_group" "network" {
+resource "azurestack_resource_group" "test" {
   name     = "production"
   location = "West US"
 }
 
 # Create a virtual network within the resource group
-resource "azurestack_virtual_network" "network" {
+resource "azurestack_virtual_network" "test" {
   name                = "production-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurestack_resource_group.network.location}"
-  resource_group_name = "${azurestack_resource_group.network.name}"
+  location            = "${azurestack_resource_group.test.location}"
+  resource_group_name = "${azurestack_resource_group.test.name}"
 
   subnet {
     name           = "subnet1"
@@ -57,38 +60,35 @@ resource "azurestack_virtual_network" "network" {
 
 The following arguments are supported:
 
-* `arm_endpoint` - (Optional) The Azure Resource Manager API Endpoint for
-  your Azure Stack instance, such as `https://management.westus.mydomain.com`.
-  It can also be sourced from the `ARM_ENDPOINT` environment variable.
+* `arm_endpoint` - (Optional) The Azure Resource Manager Endpoint for your Azure Stack instance, for example `https://management.westus.mydomain.com`. This can also be sourceed from the `ARM_ENDPOINT` Environment Variable.
 
-* `subscription_id` - (Optional) The subscription ID to use. It can also
-  be sourced from the `ARM_SUBSCRIPTION_ID` environment variable.
+* `client_id` - (Optional) The Client ID which should be used. This can also be sourceed from the `ARM_CLIENT_ID` Environment Variable.
 
-* `client_id` - (Optional) The client ID to use. It can also be sourced from
-  the `ARM_CLIENT_ID` environment variable.
+* `subscription_id` - (Optional) The Subscription ID which should be used. This can also be sourced from the `ARM_SUBSCRIPTION_ID` Environment Variable.
 
-* `client_secret` - (Optional) The client secret to use. It can also be sourced from
-  the `ARM_CLIENT_SECRET` environment variable.
+* `tenant_id` - (Optional) The Tenant ID which should be used. This can also be sourced from the `ARM_TENANT_ID` Environment Variable.
 
-* `tenant_id` - (Optional) The tenant ID to use. It can also be sourced from the
-  `ARM_TENANT_ID` environment variable.
+---
 
-* `skip_credentials_validation` - (Optional) Prevents the provider from validating
-  the given credentials. When set to `true`, `skip_provider_registration` is assumed.
-  It can also be sourced from the `ARM_SKIP_CREDENTIALS_VALIDATION` environment
-  variable; defaults to `false`.
+When authenticating as a Service Principal using a Client Secret, the following fields can be set:
 
-* `skip_provider_registration` - (Optional) Prevents the provider from registering
-  the ARM provider namespaces, this can be used if you don't wish to give the Active
-  Directory Application permission to register resource providers. It can also be
-  sourced from the `ARM_SKIP_PROVIDER_REGISTRATION` environment variable; defaults
-  to `false`.
+* `client_secret` - (Optional) The Client Secret which should be used. This can also be sourced from the `ARM_CLIENT_SECRET` Environment Variable.
+
+More information on [how to configure a Service Principal using a Client Secret can be found in this guide](auth/service_principal_client_secret.html).
+
+---
+
+For some advanced scenarios, such as where more granular permissions are necessary - the following properties can be set:
+
+* `skip_credentials_validation` - (Optional) Should the Azure Stack Provider skip verifying the credentials being used are valid? This can also be sourced from the `ARM_SKIP_CREDENTIALS_VALIDATION` Environment Variable. Defaults to `false`.
+
+* `skip_provider_registration` - (Optional) Should the Azure Stack Provider skip registering any required Resource Providers? This can also be sourced from the `ARM_SKIP_PROVIDER_REGISTRATION` Environment Variable. Defaults to `false`.
 
 ## Testing
 
 The following Environment Variables must be set to run the acceptance tests:
 
-~> **NOTE:** The Acceptance Tests require the use of a Service Principal.
+~> **NOTE:** The Acceptance Tests require the use of a Service Principal using a Client Secret.
 
 * `ARM_ENDPOINT` - The Azure Resource Manager API Endpoint for Azure Stack.
 * `ARM_SUBSCRIPTION_ID` - The ID of the Azure Subscription in which to run the Acceptance Tests.


### PR DESCRIPTION
This PR introduces support for authenticating using a Client Certificate.

I've opted to split the authentication docs out to their own folder since there's going to be three of these now (Client Cert, Client Secret and Azure CLI auth [in the next PR]). Once this is merged this'll want a redirect added to the Website from the old link -> the new link

Fixes #11