### PR TITLE
authentication: support for the Azure CLI

### DIFF
--- a/azurestack/provider.go
+++ b/azurestack/provider.go
@@ -134,6 +134,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 			Environment:                   "AZURESTACKCLOUD",
 
 			// Feature Toggles
+			SupportsAzureCliToken:    true,
 			SupportsClientSecretAuth: true,
 			SupportsClientCertAuth:   true,
 		}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0
-	github.com/hashicorp/go-azure-helpers v0.0.0-20181211121309-38db96513363
+	github.com/hashicorp/go-azure-helpers v0.3.2
 	github.com/hashicorp/go-getter v1.2.0 // indirect
 	github.com/hashicorp/go-hclog v0.8.0 // indirect
 	github.com/hashicorp/go-plugin v0.0.0-20190220160451-3f118e8ee104 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpg
 github.com/hashicorp/errwrap v0.0.0-20180715044906-d6c0cd880357/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-azure-helpers v0.0.0-20181211121309-38db96513363 h1:9d0jVlMpgfMTdL/QSsRDQsLenOQZIHp5cEBiWSYc8w4=
-github.com/hashicorp/go-azure-helpers v0.0.0-20181211121309-38db96513363/go.mod h1:Y5ejHZY3jQby82dOASJzyQ2xZw37zs+D5x6AaOC6O5E=
+github.com/hashicorp/go-azure-helpers v0.3.2 h1:nd+4DUXMm6O0CIIioFR5zvUNC+prIvwLMrTNN8FNwNo=
+github.com/hashicorp/go-azure-helpers v0.3.2/go.mod h1:lu62V//auUow6k0IykxLK2DCNW8qTmpm8KqhYVWattA=
 github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-getter v1.2.0 h1:E05bVPilzyh2yXgT6srn7WEkfMZaH+LuX9tDJw/4kaE=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -101,7 +101,7 @@ github.com/google/go-cmp/cmp/internal/value
 github.com/googleapis/gax-go/v2
 # github.com/hashicorp/errwrap v1.0.0
 github.com/hashicorp/errwrap
-# github.com/hashicorp/go-azure-helpers v0.0.0-20181211121309-38db96513363
+# github.com/hashicorp/go-azure-helpers v0.3.2
 github.com/hashicorp/go-azure-helpers/authentication
 github.com/hashicorp/go-azure-helpers/resourceproviders
 # github.com/hashicorp/go-cleanhttp v0.5.0

--- a/website/azurestack.erb
+++ b/website/azurestack.erb
@@ -25,6 +25,10 @@
             <li<%= sidebar_current("docs-azurestack-auth") %>>
               <a href="#">Authentication</a>
               <ul class="nav nav-visible">
+                <li<%= sidebar_current("docs-azurestack-auth-service-principal-azure-cli") %>>
+                    <a href="/docs/providers/azurestack/auth/azure_cli.html">using the Azure CLI</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azurestack-auth-service-principal-client-certificate") %>>
                     <a href="/docs/providers/azurestack/auth/service_principal_client_certificate.html">via Service Principal (Client Certificate)</a>
                 </li>

--- a/website/docs/auth/azure_cli.html.markdown
+++ b/website/docs/auth/azure_cli.html.markdown
@@ -1,0 +1,117 @@
+---
+layout: "azurestack"
+page_title: "Azure Stack Provider: Authenticating using the Azure CLI"
+sidebar_current: "docs-azurestack-auth-service-principal-azure-cli"
+description: |-
+  This guide explains how to authenticate using the Azure CLI with the Azure Stack Provider.
+
+---
+
+# Azure Stack Provider: Authenticating using the Azure CLI
+
+Terraform supports authenticating to Azure Stack using the Azure CLI, a Service Principal (either using a Client Secret or a Client Certificate).
+
+Terraform supports authenticating to Azure Stack using the Azure CLI (which is detailed in this guide) or a Service Principal, either [using a Client Secret](service_principal_client_secret.html) or [using a Client Certificate](service_principal_client_certificate.html).
+
+~> **NOTE:** Authenticating via the Azure CLI is only supported when using a User Account. If you're using a Service Principal (for example via `az login --service-principal`) you should instead [authenticate via the Service Principal directly](service_principal_client_secret.html).
+
+This guide assumes that the Certificate being used for Azure Stack is valid, or has been trusted on your machine ([instructions for trusting the Azure Stack Certificate can be found here](https://docs.microsoft.com/en-us/azure/azure-stack/user/azure-stack-version-profiles-azurecli2#trust-the-azure-stack-ca-root-certificate)).
+
+---
+
+We need to add the details for your Azure Stack Configuration to the Azure CLI:
+
+```shell
+$ az cloud register -n AzureStack --endpoint-resource-manager "https://management.region.mycloud.com" --suffix-storage-endpoint "region.mycloud.com" --suffix-keyvault-dns ".vault.region.mycloud.com"
+```
+
+-> Note: the values used will differ from the ones specified in the example above - as such you may need to contact your Azure Stack Administrator to determine the values required to connect to your Azure Stack instance.
+
+Once that's done we can now switch to using the newly registered `AzureStack` cloud:
+
+```shell
+$ az cloud set --name AzureStack
+```
+
+Next you'll need to configure the Profile used for Azure Stack:
+
+```shell
+$ az cloud update --profile 2018-03-01-hybrid
+```
+
+-> **NOTE:** If you're using a version of Azure Stack prior to build 1808 - you'll need to use the Profile version `2017-03-09-profile`.
+
+---
+
+At this point we should be able to log into the Azure Stack instance using the Azure CLI:
+
+```shell
+$ az login
+```
+
+~> **NOTE:** Authenticating via the Azure CLI is only supported when using a User Account. If you're using a Service Principal (for example via `az login --service-principal`) you should instead [authenticate via the Service Principal directly](service_principal_client_secret.html).
+
+This will prompt you to open a web browser, as shown below:
+
+```shell
+$ az login
+Note, we have launched a browser for you to login. For old experience with device code, use "az login --use-device-code
+```
+
+Once logged in, it's possible to list the Subscriptions associated with the account via:
+
+```shell
+$ az account list
+```
+
+The output (similar to below) will display one or more Subscriptions:
+
+```json
+[
+  {
+    "cloudName": "AzureStack",
+    "id": "00000000-0000-0000-0000-000000000000",
+    "isDefault": true,
+    "name": "Example Subscription",
+    "state": "Enabled",
+    "tenantId": "00000000-0000-0000-0000-000000000000",
+    "user": {
+      "name": "user@example.com",
+      "type": "user"
+    }
+  }
+]
+```
+
+In the snippet above, `id` refers to the Subscription ID and `isDefault` refers to whether this Subscription is configured as the default.
+
+~> **Note:** When authenticating via the Azure CLI, Terraform will automatically connect to the Default Subscription. Therefore, if you have multiple subscriptions on the account, you may need to set the Default Subscription, via:
+
+```shell
+$ az account set --subscription="SUBSCRIPTION_ID"
+```
+
+## Configuring the Provider block when using the Azure CLI
+
+When authenticating using the Azure CLI most of the details required can be inferred, as such to use the Default Subscription configured in the Azure CLI you should be able to use the following Provider Block:
+
+```
+provider "azurestack" {
+  # whilst the version attribute is optional, we recommend pinning the Provider version being used
+  version = "=0.5.0"
+}
+```
+
+If you're using multiple subscriptions (or have access to multiple tenants) - it's possible to specify the Subscription ID to target a specific Subscription:
+
+```
+provider "azurestack" {
+  # whilst the version attribute is optional, we recommend pinning the Provider version being used
+  version         = "=0.5.0"
+  subscription_id = "00000000-0000-0000-0000-000000000000"
+}
+```
+
+More information on [the fields supported in the Provider block can be found here](../index.html#argument-reference).
+
+~> **NOTE:** If you're previously authenticated using a Service Principal (configured via Environment Variables) - you must remove the `ARM_*` prefixed Environment Variables in order to be able to authenticate using the Azure CLI.

--- a/website/docs/auth/service_principal_client_certificate.html.markdown
+++ b/website/docs/auth/service_principal_client_certificate.html.markdown
@@ -9,7 +9,7 @@ description: |-
 
 # Azure Stack Provider: Authenticating using a Service Principal using a Client Certificate
 
-Terraform supports authenticating to Azure Stack using a Service Principal, either [using a Client Secret](service_principal_client_secret.html) or using a Client Certificate (which is detailed in this guide).
+Terraform supports authenticating to Azure Stack using [the Azure CLI](azure_cli.html) or a Service Principal, either [using a Client Secret](service_principal_client_secret.html) or using a Client Certificate (which is detailed in this guide).
 
 ## Creating a Service Principal
 

--- a/website/docs/auth/service_principal_client_secret.html.markdown
+++ b/website/docs/auth/service_principal_client_secret.html.markdown
@@ -9,7 +9,7 @@ description: |-
 
 # Azure Stack Provider: Authenticating using a Service Principal using a Client Secret
 
-Terraform supports authenticating to Azure Stack using a Service Principal, either using a Client Secret (which is detailed in this guide) or [using a Client Certificate](service_principal_client_certificate.html).
+Terraform supports authenticating to Azure Stack using [the Azure CLI](azure_cli.html) or a Service Principal, either using a Client Secret (which is detailed in this guide) or [using a Client Certificate](service_principal_client_certificate.html).
 
 ## Creating a Service Principal
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -15,7 +15,7 @@ Use the navigation to the left to read about the available resources.
 
 # Creating Credentials
 
-Terraform supports authenticating to Azure Stack using a Service Principal, either using [Client Secret](auth/service_principal_client_secret.html) or a [Client Certificate](auth/service_principal_client_certificate.html).
+Terraform supports authenticating to Azure Stack using [the Azure CLI](auth/azure_cli.html) or a Service Principal (either using a [Client Secret](auth/service_principal_client_secret.html) or a [Client Certificate](auth/service_principal_client_certificate.html)).
 
 ## Example Usage
 


### PR DESCRIPTION
This PR adds support for authenticating using the Azure CLI. Since it's based on top of #56, it needs to be merged after that.