### PR TITLE
azurestack_virtual_network_gateway: fix panic if bgp_settings is set with 0 elements

### DIFF
--- a/azurestack/resource_arm_virtual_network_gateway.go
+++ b/azurestack/resource_arm_virtual_network_gateway.go
@@ -460,6 +460,10 @@ func getArmVirtualNetworkGatewayProperties(d *schema.ResourceData) (*network.Vir
 
 func expandArmVirtualNetworkGatewayBgpSettings(d *schema.ResourceData) *network.BgpSettings {
 	bgpSets := d.Get("bgp_settings").([]interface{})
+	if len(bgpSets) == 0 {
+		return nil
+	}
+
 	bgp := bgpSets[0].(map[string]interface{})
 
 	peeringAddress := bgp["peering_address"].(string)


### PR DESCRIPTION
fixes #60 