### PR TITLE
website: Update link to `file` function

### DIFF
--- a/website/docs/r/template_deployment.html.markdown
+++ b/website/docs/r/template_deployment.html.markdown
@@ -112,7 +112,7 @@ The following arguments are supported:
     specified within the template, and Terraform will not be aware of this.
 * `template_body` - (Optional) Specifies the JSON definition for the template.
 
-~> **Note:** There's an [`file` interpolation function available](https://www.terraform.io/docs/configuration/interpolation.html#file-path-) which allows you to read this from an external file, which helps makes this more resource more readable.
+~> **Note:** There's a [`file` function available](https://www.terraform.io/docs/configuration/functions/file.html) which allows you to read this from an external file, which helps makes this more resource more readable.
 
 * `parameters` - (Optional) Specifies the name and value pairs that define the deployment parameters for the template.
 


### PR DESCRIPTION
Although this redirects to a legible spot right now, it's for the 0.11 language docs, which won't be "current" for much longer. This new link goes to the 0.12 version of the file function.

This commit should be cherry-picked to stable-website once merged.