### PR TITLE
r/storage_account: parsing the account name from either casing

### DIFF
--- a/azurestack/resource_arm_storage_account.go
+++ b/azurestack/resource_arm_storage_account.go
@@ -321,6 +321,12 @@ func resourceArmStorageAccountUpdate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 	storageAccountName := id.Path["storageaccounts"]
+	// https://github.com/terraform-providers/terraform-provider-azurestack/issues/98
+	// it appears the casing of the Resource ID's changed in Azure Stack version 1905
+	// as such we need to confirm both casings
+	if storageAccountName == "" {
+		storageAccountName = id.Path["storageAccounts"]
+	}
 	resourceGroupName := id.ResourceGroup
 
 	accountTier := d.Get("account_tier").(string)
@@ -441,6 +447,12 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	name := id.Path["storageaccounts"]
+	// https://github.com/terraform-providers/terraform-provider-azurestack/issues/98
+	// it appears the casing of the Resource ID's changed in Azure Stack version 1905
+	// as such we need to confirm both casings
+	if name == "" {
+		name = id.Path["storageAccounts"]
+	}
 	resGroup := id.ResourceGroup
 
 	resp, err := client.GetProperties(ctx, resGroup, name)
@@ -555,6 +567,12 @@ func resourceArmStorageAccountDelete(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 	name := id.Path["storageaccounts"]
+	// https://github.com/terraform-providers/terraform-provider-azurestack/issues/98
+	// it appears the casing of the Resource ID's changed in Azure Stack version 1905
+	// as such we need to confirm both casings
+	if name == "" {
+		name = id.Path["storageAccounts"]
+	}
 	resGroup := id.ResourceGroup
 
 	_, err = client.Delete(ctx, resGroup, name)


### PR DESCRIPTION
Azure Stack 1905 changes the casing of the Resource ID such that it's now returned as `storageAccounts` rather than `storageaccounts`. So that we keep compatibility with both previous versions and the latest version of Azure Stack - this PR switches to trying to parse the name out of both possible casings.

Unfortunately the Azure Stack instance we use hasn't been updated to 1905, so I'm unable to confirm this directly, but I believe this should fix #90 - [based on this comment](https://github.com/terraform-providers/terraform-provider-azurestack/issues/90#issuecomment-509365873)

Fixes #90 