### PR TITLE
Increase the golangci-lint timeout to 5 minutes, default was 1 minute

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,4 +28,5 @@ linters-settings:
     ignore: github.com/hashicorp/terraform-plugin-sdk/helper/schema:ForceNew|Set,fmt:.*,io:Close
 
 run:
+  deadline: 10m10s
   modules-download-mode: vendor

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -44,7 +44,7 @@ goimport:
 
 lint:
 	@echo "==> Checking source code against linters..."
-	golangci-lint run ./...
+	golangci-lint run ./... --timeout=5m0s
 
 tools:
 	@echo "==> installing required tooling..."

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -44,7 +44,7 @@ goimport:
 
 lint:
 	@echo "==> Checking source code against linters..."
-	golangci-lint run ./... --timeout=5m0s
+	golangci-lint run ./...
 
 tools:
 	@echo "==> installing required tooling..."


### PR DESCRIPTION
Increase the lint task timeout to 5 minutes to fix travis built errors due to lint timeout after one minute